### PR TITLE
Add endpoint to record cash payments

### DIFF
--- a/db.js
+++ b/db.js
@@ -4,7 +4,8 @@ const base = new Airtable({ apiKey: process.env.AIRTABLE_KEY }).base(process.env
 const Table = {
     Inventory: 'Inventory',
     Borrowers: 'Members',
-    Loans: 'Loans'
+    Loans: 'Loans',
+    Payments: 'Transactions'
 };
 
 const BorrowerIssue = {

--- a/lending/index.js
+++ b/lending/index.js
@@ -4,10 +4,12 @@ const authentication = require('../middleware/supabaseAuthentication');
 const thingsEndpoint = require('./routes/things');
 const borrowersEndpoint = require('./routes/borrowers');
 const loansEndpoint = require('./routes/loans');
+const paymentsEndpoint = require('./routes/payments');
 
 router.use(authentication);
 router.use('/things', thingsEndpoint);
 router.use('/borrowers', borrowersEndpoint);
 router.use('/loans', loansEndpoint);
+router.use('/payments', paymentsEndpoint);
 
 module.exports = router;

--- a/lending/routes/payments.js
+++ b/lending/routes/payments.js
@@ -1,0 +1,18 @@
+const { recordCashPayment } = require('../../services/payments');
+
+const express = require('express');
+const router = express.Router();
+
+router.put('/:borrowerId', async (req, res) => {
+    const { borrowerId } = req.params;
+    const { cash } = req.body;
+    try {
+        const paymentId = await recordCashPayment({ borrowerId, cash });
+        res.status(201).send({ id: paymentId });
+    } catch (error) {
+        console.error(error);
+        res.status(500).send({ error });
+    }
+});
+
+module.exports = router;

--- a/services/payments.js
+++ b/services/payments.js
@@ -1,0 +1,21 @@
+const { base, Table } = require('../db');
+
+const payments = base(Table.Payments);
+
+const recordCashPayment = async ({
+    borrowerId,
+    cash
+}) => {
+    const today = new Date(Date.now());
+    const payment = await payments.create({
+        "member": [borrowerId],
+        "date": today.toISOString(),
+        cash
+    });
+
+    return payment.id;
+};
+
+module.exports = {
+    recordCashPayment
+};


### PR DESCRIPTION
This is to support a new feature in the Librarian app, where librarians will be able to record dues payments for members. This is currently only possible in Airtable.